### PR TITLE
Pull the rip-cord to turn off payments

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -68,17 +68,17 @@ module.exports.routes = {
   'POST /address/:userId': 'AddressController.addUserAddress',
 
   //Stripe payments routes
-  'GET /payments/getManagedAccount/:userId': 'PaymentsStripeController.getManagedAccount',//
-  'GET /payments/getCustomer/:userId': 'PaymentsStripeController.getCustomer',//
-  'GET /payments/:userId': 'PaymentsStripeController.getPayments', //
-  'GET /payments/bankBalance/:userId': 'PaymentsStripeController.getManagedBalance', //
-  'DELETE /payments/deletePaymentMethod/:userId': 'PaymentsStripeController.deletePaymentMethod',//
-  'DELETE /payments/deleteCustomer/:userId': 'PaymentsStripeController.deleteCustomer',//
-  'DELETE /payments/deleteExternalAccount/:userId': 'PaymentsStripeController.deleteExternalAccount',//
-  'DELETE /payments/deleteManagedAccount/:userId': 'PaymentsStripeController.deleteManagedAccount',//
-  'POST /payments/createManagedAccount/:userId': 'PaymentsStripeController.createManagedAccount',//
-  'POST /payments/createCustomerAndPaymentMethod': 'PaymentsStripeController.createCustomerAndPaymentMethod',//
-  'POST /payments/createOrder': 'PaymentsStripeController.createOrder',//
+  // 'GET /payments/getManagedAccount/:userId': 'PaymentsStripeController.getManagedAccount',//
+  // 'GET /payments/getCustomer/:userId': 'PaymentsStripeController.getCustomer',//
+  // 'GET /payments/:userId': 'PaymentsStripeController.getPayments', //
+  // 'GET /payments/bankBalance/:userId': 'PaymentsStripeController.getManagedBalance', //
+  // 'DELETE /payments/deletePaymentMethod/:userId': 'PaymentsStripeController.deletePaymentMethod',//
+  // 'DELETE /payments/deleteCustomer/:userId': 'PaymentsStripeController.deleteCustomer',//
+  // 'DELETE /payments/deleteExternalAccount/:userId': 'PaymentsStripeController.deleteExternalAccount',//
+  // 'DELETE /payments/deleteManagedAccount/:userId': 'PaymentsStripeController.deleteManagedAccount',//
+  // 'POST /payments/createManagedAccount/:userId': 'PaymentsStripeController.createManagedAccount',//
+  // 'POST /payments/createCustomerAndPaymentMethod': 'PaymentsStripeController.createCustomerAndPaymentMethod',//
+  //'POST /payments/createOrder': 'PaymentsStripeController.createOrder',//
   
   //Stripe Webhooks
   'POST /payments/webhook/event': 'WebhooksController.stripeEvent',//


### PR DESCRIPTION
Suppose UserA and UserB are both fully authenticated users which
have purchased and sold (aka they have set up payment methods stored
in the db).

Given that we have full api and listing access because the API is only
secured at the border via bearer token, we can repeatedly call
/userlistings/create + /createOrder to drain either user's bank account.

We need to turn off payments 100% until we know it's secure.

@jordanharris to merge.
